### PR TITLE
fix permission problems on some secure setuid shebang platform

### DIFF
--- a/src/mystate.h
+++ b/src/mystate.h
@@ -5,8 +5,17 @@
 * 摘	要：改变认证状态
 * 作	者：HustMoon@BYHH
 */
+
+/*
+ * modified by shilianggoo@gmail.com
+ * add NEED_LOGOUT, fix permission problems
+ * in some secure setuid shebang implemention
+ */
+
 #ifndef HUSTMOON_MYSTATE_H
 #define HUSTMOON_MYSTATE_H
+
+#define NEED_LOGOUT
 
 #define ID_DISCONNECT		0	/* 断开状态 */
 #define ID_START			1	/* 寻找服务器 */


### PR DESCRIPTION
on some secure setuid shebang platform, 带setuid的mentohust运行dhcpscript时会失去setuid，无法获取ip地址