### PR TITLE
当强制转换到char型时指明为有符号类型

### DIFF
--- a/src/checkV4.c
+++ b/src/checkV4.c
@@ -1032,7 +1032,7 @@ unsigned char *computeV4(const unsigned char *src, int len)
 
             for (i=0; i<8; ++i)
             {
-                sprintf(tbuf, "%02x", (char)(s[2*i]));
+                sprintf(tbuf, "%02x", (signed char)(s[2*i]));
                 strcpy((char*)wtmp + wpos, tbuf);
                 wpos += strlen(tbuf);
             }
@@ -1047,7 +1047,7 @@ unsigned char *computeV4(const unsigned char *src, int len)
             }
             for (i=0; i<8; ++i)
             {
-                sprintf(tbuf, "%02x", (char)(s[2*i+1]));
+                sprintf(tbuf, "%02x", (signed char)(s[2*i+1]));
                 strcpy((char*)wtmp + wpos, tbuf);
                 wpos += strlen(tbuf);
             }


### PR DESCRIPTION
可（部分）解决 #265 . 由于我将在`switch`之前的部分引入新的更改，在此更新`switch`之前的char将造成合并冲突，故这里先不更改前两个类型转换。