### PR TITLE
增加长选项支持

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,11 @@ AS_IF([test "x$enable_logout" = "xno"],
 
 AS_IF([test -z "$enable_nls"], [enable_nls="yes"])
 
+AC_ARG_ENABLE([getopt-long], [AC_HELP_STRING([ --disable-getopt-long], [Don't use long options (and getopt_log())])],
+              [], [enable_getopt_long="yes"])
+AS_IF([test "x$enable_getopt_long" = "xno"],
+      [AC_DEFINE(NO_GETOPT_LONG, [], [Define NO_ETOPT_LONG to disable using of getopt_long() to parse options])])
+
 GETTEXT_PACKAGE="$PACKAGE_NAME"
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Package name for gettext.])
@@ -75,5 +80,5 @@ AC_CHECK_FUNCS([atexit memmove memset socket strrchr setlocale])
 
 AC_CONFIG_FILES([Makefile src/Makefile po/Makefile.in mentohust.spec])
 
-AC_MSG_RESULT([config result: host($host_os) pcap($with_pcap) notify($enable_notify) encode($enable_encodepass) arp($enable_arp) nls($enable_nls)])
+AC_MSG_RESULT([config result: host($host_os) pcap($with_pcap) notify($enable_notify) encode($enable_encodepass) arp($enable_arp) nls($enable_nls) getopt_long($enable_getopt_long)])
 AC_OUTPUT

--- a/src/myconfig.c
+++ b/src/myconfig.c
@@ -362,7 +362,7 @@ static void readArg(char argc, char **argv, int *saveFlag, int *exitFlag, int *d
 	    { "heartbeat", required_argument, NULL, 'e' },
 	    { "wait-after-fail", required_argument, NULL, 'r' },
 	    { "max-fail", required_argument, NULL, 'l' },
-	    { "eap-broadcast-addr", required_argument, NULL, 'a' },
+	    { "eap-bcast-addr", required_argument, NULL, 'a' },
 	    { "dhcp-type", required_argument, NULL, 'd' },
 	    { "daemonize", required_argument, NULL, 'b' },
 #ifndef NO_NOTIFY
@@ -548,33 +548,102 @@ static void readArg(char argc, char **argv, int *saveFlag, int *exitFlag, int *d
 static void showHelp(const char *fileName)
 {
 	char *helpString =
-		_("用法:\t%s [-选项][参数]\n"
-		"选项:\t-h 显示本帮助信息\n"
+		_("用法:\t%s [-选项][参数] 或 [-选项] [参数] 或 [--长选项] [参数]\n选项:"
+#ifndef NO_GETOPT_LONG
+        "\t--help"
+#endif
+		"\t-h 显示本帮助信息\n"
+#ifndef NO_GETOPT_LONG
+        "\t--kill"
+#endif
 		"\t-k -k(退出程序) 其他(重启程序)\n"
+#ifndef NO_GETOPT_LONG
+        "\t--write"
+#endif
 		"\t-w 保存参数到配置文件\n"
+#ifndef NO_GETOPT_LONG
+        "\t--username"
+#endif
 		"\t-u 用户名\n"
+#ifndef NO_GETOPT_LONG
+        "\t--password"
+#endif
 		"\t-p 密码\n"
+#ifndef NO_GETOPT_LONG
+        "\t--nic"
+#endif
 		"\t-n 网卡名\n"
+#ifndef NO_GETOPT_LONG
+        "\t--ip"
+#endif
 		"\t-i IP[默认本机IP]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--mask"
+#endif
 		"\t-m 子网掩码[默认本机掩码]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--gateway"
+#endif
 		"\t-g 网关[默认0.0.0.0]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--dns"
+#endif
 		"\t-s DNS[默认0.0.0.0]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--ping-host"
+#endif
 		"\t-o Ping主机[默认0.0.0.0，表示关闭该功能]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--auth-timeout"
+#endif
 		"\t-t 认证超时(秒)[默认8]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--heartbeat"
+#endif
 		"\t-e 心跳间隔(秒)[默认30]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--wait-after-fail"
+#endif
 		"\t-r 失败等待(秒)[默认15]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--max-fail"
+#endif
 		"\t-l 允许失败次数[0表示无限制，默认8]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--eap-bcast-addr"
+#endif
 		"\t-a 组播地址: 0(标准) 1(锐捷) 2(赛尔) [默认0]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--dhcp-type"
+#endif
 		"\t-d DHCP方式: 0(不使用) 1(二次认证) 2(认证后) 3(认证前) [默认0]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--daemonize"
+#endif
 		"\t-b 是否后台运行: 0(否) 1(是，关闭输出) 2(是，保留输出) 3(是，输出到文件) [默认0]\n"
 #ifndef NO_NOTIFY
+#ifndef NO_GETOPT_LONG
+        "\t--notify"
+#endif
 		"\t-y 是否显示通知: 0(否) 1~20(是) [默认5]\n"
 #endif
+#ifndef NO_GETOPT_LONG
+        "\t--fake-supplicant-version"
+#endif
 		"\t-v 客户端版本号[默认0.00表示兼容xrgsu]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--template-file"
+#endif
 		"\t-f 自定义数据文件[默认不使用]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--dhcp-script"
+#endif
 		"\t-c DHCP脚本[默认dhclient]\n"
+#ifndef NO_GETOPT_LONG
+        "\t--decode-config"
+#endif
 		"\t-q 显示SuConfig.dat的内容(如-q/path/SuConfig.dat)\n"
-		"例如:\t%s -uusername -ppassword -neth0 -i192.168.0.1 -m255.255.255.0 -g0.0.0.0 -s0.0.0.0 -o0.0.0.0 -t8 -e30 -r15 -a0 -d1 -b0 -v4.10 -fdefault.mpf -cdhclient\n"
+		"例如:\t%s -u username -p password -n eth0 -i 192.168.0.1 -m 255.255.255.0 -g 0.0.0.0 -s 0.0.0.0 -o 0.0.0.0 -t 8 -e 30 -r 15 -a 0 -d 1 -b 0 -v 4.10 -f default.mpf -c dhclient\n"
 		"注意：使用时请确保是以root权限运行！\n\n");
 	printf(helpString, fileName, fileName);
 	//cancel the registered funciton:atexit(exit_handle)


### PR DESCRIPTION
目前26个字母的选项已经快要用完了，再加参数的话就需要引入长选项了。

这个功能可在编译时控制开启或关闭，默认开启。重新生成configure后即可使用，可通过`./configure --disable-getopt-long`来关闭。

引入长选项后，可使用的参数格式也多了两种：

* `-u john`
* `--username john`

而原来的`-ujohn`也能够兼容。多种参数格式的支持也使得命令行更容易配置。

唯一的问题是`getopt_long()`是GNU扩展，但试了一下uClibc和musl也都可以使用。这样一来大部分设备就都能用了。希望`getopt_long()`已经成为事实标准……