### PR TITLE
增加修改服务名的选项

### DIFF
--- a/src/myconfig.c
+++ b/src/myconfig.c
@@ -33,6 +33,7 @@ static const char *PACKAGE_BUGREPORT = "http://code.google.com/p/mentohust/issue
 
 #define ACCOUNT_SIZE		65	/* 用户名密码长度*/
 #define NIC_SIZE			16	/* 网卡名最大长度 */
+#define SERVICE_SIZE		127	/* 服务名最大长度 */
 #define MAX_PATH			255	/* FILENAME_MAX */
 #define D_TIMEOUT			8	/* 默认超时间隔 */
 #define D_ECHOINTERVAL		30	/* 默认心跳间隔 */
@@ -41,6 +42,7 @@ static const char *PACKAGE_BUGREPORT = "http://code.google.com/p/mentohust/issue
 #define D_DHCPMODE			0	/* 默认DHCP模式 */
 #define D_DAEMONMODE		0	/* 默认daemon模式 */
 #define D_MAXFAIL			8	/* 默认允许失败次数 */
+#define D_SERVICENAME		"internet"	/* 默认要登录的服务名 */
 
 #define ECHOFLAGS (ECHO|ECHOE|ECHOK|ECHONL)    /* 控制台输入密码时的模式*/
 
@@ -66,6 +68,7 @@ char password[ACCOUNT_SIZE] = "";	/* 密码 */
 char nic[NIC_SIZE] = "";	/* 网卡名 */
 char dataFile[MAX_PATH] = "";	/* 数据文件 */
 char dhcpScript[MAX_PATH] = "";	/* DHCP脚本 */
+char serviceName[SERVICE_SIZE] = ""; /* 需要登陆到的服务名 */
 u_int32_t ip = 0;	/* 本机IP */
 u_int32_t mask = 0;	/* 子网掩码 */
 u_int32_t gateway = 0;	/* 网关 */
@@ -208,6 +211,7 @@ void initConfig(int argc, char **argv)
 	int saveFlag = 0;	/* 是否需要保存参数 */
 	int exitFlag = 0;	/* 0Nothing 1退出 2重启 */
 	int daemonMode = D_DAEMONMODE;	/* 是否后台运行 */
+	void customizeServiceName(char* service); /* myconfig.c中用于更改服务名的函数 */
 
 	printf(_("\n欢迎使用MentoHUST\t版本: %s\n"
 			"Copyright (C) 2009-2010 HustMoon Studio\n"
@@ -264,6 +268,9 @@ void initConfig(int argc, char **argv)
 	}
 	if (dhcpScript[0] == '\0')	/* 未填写DHCP脚本？ */
 		strcpy(dhcpScript, D_DHCPSCRIPT);
+	if (serviceName[0] == '\0') /* 未填写服务名？ */
+		strcpy(serviceName, D_SERVICENAME);
+	customizeServiceName(serviceName);
 	newBuffer();
 	printConfig();
 	if (fillHeader()==-1 || openPcap()==-1) {	/* 获取IP、MAC，打开网卡 */
@@ -303,6 +310,7 @@ static int readFile(int *daemonMode)
 	getString(buf, "MentoHUST", "Datafile", "", dataFile, sizeof(dataFile));
 	getString(buf, "MentoHUST", "DhcpScript", "", dhcpScript, sizeof(dhcpScript));
 	getString(buf, "MentoHUST", "Version", "", tmp, sizeof(tmp));
+	getString(buf, "MentoHUST", "ServiceName", D_SERVICENAME, serviceName, sizeof(serviceName));
 	if (strlen(tmp) >= 3) {
 		unsigned ver[2];
 		if (sscanf(tmp, "%u.%u", ver, ver+1)!=EOF && ver[0]!=0) {
@@ -372,6 +380,7 @@ static void readArg(char argc, char **argv, int *saveFlag, int *exitFlag, int *d
 	    { "template-file", required_argument, NULL, 'f' },
 	    { "dhcp-script", required_argument, NULL, 'c' },
 	    { "decode-config", required_argument, NULL, 'q' },
+	    { "service", required_argument, NULL, 0},
 	    { NULL, no_argument, NULL, 0 }
     };
 
@@ -460,6 +469,12 @@ static void readArg(char argc, char **argv, int *saveFlag, int *exitFlag, int *d
             case 'q':
                 printSuConfig(optarg);
                 exit(EXIT_SUCCESS);
+            case 0: /* 超出26个字母的选项，没有短选项与其对应 */
+#define IF_ARG(arg_name) (strcmp(longOpts[longIndex].name, arg_name) == 0)
+                if (IF_ARG("service")) {
+                    COPY_ARG_TO(serviceName);
+                }
+                break;
             default:
                 break;
         }
@@ -643,6 +658,10 @@ static void showHelp(const char *fileName)
         "\t--decode-config"
 #endif
 		"\t-q 显示SuConfig.dat的内容(如-q/path/SuConfig.dat)\n"
+#ifndef NO_GETOPT_LONG
+		/* 从这里开始就是必须使用长选项的参数了 */
+		"\t--service 要登陆到的服务名 [默认internet]\n"
+#endif
 		"例如:\t%s -u username -p password -n eth0 -i 192.168.0.1 -m 255.255.255.0 -g 0.0.0.0 -s 0.0.0.0 -o 0.0.0.0 -t 8 -e 30 -r 15 -a 0 -d 1 -b 0 -v 4.10 -f default.mpf -c dhclient\n"
 		"注意：使用时请确保是以root权限运行！\n\n");
 	printf(helpString, fileName, fileName);
@@ -699,6 +718,7 @@ static void printConfig()
 	printf(_("** 用户名:\t%s\n"), userName);
 	/* printf("** 密码:\t%s\n", password); */
 	printf(_("** 网卡: \t%s\n"), nic);
+	printf(_("** 服务名:\t%s\n"), serviceName);
 	if (gateway)
 		printf(_("** 网关地址:\t%s\n"), formatIP(gateway));
 	if (dns)

--- a/src/mystate.c
+++ b/src/mystate.c
@@ -256,6 +256,10 @@ static const unsigned char pkt3[519] = {
 0x00                                            /* . */
 };
 
+static unsigned char* pkt_start;
+static unsigned char* pkt_identity;
+static unsigned char* pkt_md5;
+
 static void setTimer(unsigned interval);	/* 设置定时器 */
 static int renewIP();	/* 更新IP */
 static void fillEtherAddr(u_int32_t protocol);  /* 填充MAC地址和协议 */
@@ -274,6 +278,33 @@ static void setTimer(unsigned interval) /* 设置定时器 */
 	timer.it_interval.tv_sec = interval;
 	timer.it_interval.tv_usec = 0;
 	setitimer(ITIMER_REAL, &timer, NULL);
+}
+
+void customizeServiceName(char* service)
+{
+	if (strncmp(service, "internet", 8) != 0) {
+		int serviceNameLen = strnlen(service, 128);
+
+		pkt_start = (unsigned char*)malloc(sizeof(pkt1));
+		pkt_identity = (unsigned char*)malloc(sizeof(pkt2));
+		pkt_md5 = (unsigned char*)malloc(sizeof(pkt3));
+
+		memmove(pkt_start, pkt1, sizeof(pkt1));
+		memmove(pkt_identity, pkt2, sizeof(pkt2));
+		memmove(pkt_md5, pkt3, sizeof(pkt3));
+
+		memset(pkt_start + 360, 0, 8);
+		memset(pkt_identity + 343, 0, 8);
+		memset(pkt_md5 + 360, 0, 8);
+
+		memmove(pkt_start + 360, service, serviceNameLen);
+		memmove(pkt_identity + 343, service, serviceNameLen);
+		memmove(pkt_md5 + 360, service, serviceNameLen);
+	} else {
+		pkt_start = pkt1;
+		pkt_identity = pkt2;
+		pkt_md5 = pkt3;
+	}
 }
 
 int switchState(int type)
@@ -390,8 +421,8 @@ static int sendStartPacket()
 		printf(_(">> 寻找服务器...\n"));
 		//fillStartPacket();
 		fillEtherAddr(0x888E0101);
-		memcpy(sendPacket + 0x12, pkt1, sizeof(pkt1));
-                memcpy(sendPacket + 0xe2, computeV4(pad, 16), 0x80);
+		memcpy(sendPacket + 0x12, pkt_start, sizeof(pkt1));
+		memcpy(sendPacket + 0xe2, computeV4(pad, 16), 0x80);
 		setTimer(timeout);
 	}
 	return pcap_sendpacket(hPcap, sendPacket, 521);
@@ -428,8 +459,8 @@ static int sendIdentityPacket()
 		sendPacket[0x13] = capBuf[0x13];
 		sendPacket[0x16] = 0x01;
 		memcpy(sendPacket+0x17, userName, nameLen);
-		memcpy(sendPacket+0x17+nameLen, pkt2, sizeof(pkt2));
-                memcpy(sendPacket + 0xe7 + nameLen, computeV4(pad, 16), 0x80);
+		memcpy(sendPacket+0x17+nameLen, pkt_identity, sizeof(pkt2));
+		memcpy(sendPacket + 0xe7 + nameLen, computeV4(pad, 16), 0x80);
 		setTimer(timeout);
 	}
 	return pcap_sendpacket(hPcap, sendPacket, 536);
@@ -468,11 +499,11 @@ static int sendChallengePacket()
 		memcpy(sendPacket+0x18, checkPass(capBuf[0x13], capBuf+0x18, capBuf[0x17]), 16);
 		memcpy(sendPacket+0x28, userName, nameLen);
 
-                memcpy(sendPacket+0x28+nameLen, pkt3, sizeof(pkt3));
-                memcpy(sendPacket + 0x90 + nameLen, computePwd(capBuf+0x18), 0x10);
-                //memcpy(sendPacket + 0xa0 +nameLen, fillBuf + 0x68, fillSize-0x68);
-                memcpy(sendPacket + 0x108 + nameLen, computeV4(capBuf+0x18, capBuf[0x17]), 0x80);
-                //sendPacket[0x77] = 0xc7;
+		memcpy(sendPacket+0x28+nameLen, pkt_md5, sizeof(pkt3));
+		memcpy(sendPacket + 0x90 + nameLen, computePwd(capBuf+0x18), 0x10);
+		//memcpy(sendPacket + 0xa0 +nameLen, fillBuf + 0x68, fillSize-0x68);
+		memcpy(sendPacket + 0x108 + nameLen, computeV4(capBuf+0x18, capBuf[0x17]), 0x80);
+		//sendPacket[0x77] = 0xc7;
 		setTimer(timeout);
 	}
 	return pcap_sendpacket(hPcap, sendPacket, 569);
@@ -520,7 +551,7 @@ static int sendLogoffPacket()
 	memcpy(sendPacket+0x12, fillBuf, fillSize);
 	return pcap_sendpacket(hPcap, sendPacket, 0x3E8);
 #else
-    return 0;
+	return 0;
 #endif
 }
 


### PR DESCRIPTION
首先检测当前指定的服务名是否是internet，若不是，则把pkt1/2/3都在内存里复制一份，然后修改其中的服务名。

目前只是修改pkt1/2/3副本里的服务名那几个字节，ZS已确认可用，其他地方未测。

因为字母用完了，故只能通过长选项`--service my_service`来使用（也就意味着长选项必须开启，即在`configure`时不要提供`--disable-getopt-long`）。中文的话，用Shell转义序列应该可以吧，并没有条件来测试……