### PR TITLE
修正服务名的偏移量

### DIFF
--- a/src/mystate.c
+++ b/src/mystate.c
@@ -293,12 +293,12 @@ void customizeServiceName(char* service)
 		memmove(pkt_identity, pkt2, sizeof(pkt2));
 		memmove(pkt_md5, pkt3, sizeof(pkt3));
 
-		memset(pkt_start + 360, 0, 8);
-		memset(pkt_identity + 343, 0, 8);
+		memset(pkt_start + 344, 0, 8);
+		memset(pkt_identity + 344, 0, 8);
 		memset(pkt_md5 + 360, 0, 8);
 
-		memmove(pkt_start + 360, service, serviceNameLen);
-		memmove(pkt_identity + 343, service, serviceNameLen);
+		memmove(pkt_start + 344, service, serviceNameLen);
+		memmove(pkt_identity + 344, service, serviceNameLen);
 		memmove(pkt_md5 + 360, service, serviceNameLen);
 	} else {
 		pkt_start = pkt1;


### PR DESCRIPTION
很奇怪之前服务端是怎么给认证通过的，而且服务还是正确的……

`setProperty()` 看起来通用很多，但是不知道为什么会segfault。还没有深究这里，暂且这样吧……