### PR TITLE
保存 --service 选项的值

### DIFF
--- a/src/myconfig.c
+++ b/src/myconfig.c
@@ -812,6 +812,7 @@ static void saveConfig(int daemonMode)
 	setString(&buf, "MentoHUST", "Password", pass);
 #endif
 	setString(&buf, "MentoHUST", "Username", userName);
+	setString(&buf, "MentoHUST", "ServiceName", serviceName);
 	if (saveFile(buf, CFG_FILE) != 0)
 		printf(_("!! 保存认证参数到%s失败！\n"), CFG_FILE);
 	else


### PR DESCRIPTION
myini.c 的代码看起来是找到第一个等号就开始判断Key是否相等，若相等就把后面的所有内容都作为Value。这样看起来，GBK编码的字符放在这里不会引发问题。在Debian Stretch里实测也能正确读写GBK编码的服务名。

我有点怀疑当时是不是提交错分支了……